### PR TITLE
Use release version of bagit 1.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2017 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 
@@ -42,11 +42,10 @@ setup(
                       'tzlocal',
                       'requests',
                       'certifi',
-                      'bagit==1.5.4.dev-4',
+                      'bagit==1.5.4',
                       'bagit-profile==1.0.2.dev',
                       'globus-sdk'],
     dependency_links=[
-         "http://github.com/ini-bdds/bagit-python/archive/master.zip#egg=bagit-1.5.4.dev-4",
          "http://github.com/ini-bdds/bagit-profiles-validator/archive/master.zip#egg=bagit-profile-1.0.2.dev"
     ],
     license='Apache 2.0',


### PR DESCRIPTION
Presumably the official bagit 1.5.4 can replace 1.5.4.dev-4?
(what aboug bagit-profiles-validator?)