### PR TITLE
Fixed bug for fetching files on Globus Endpoint

### DIFF
--- a/bdbag/fetch/transports/fetch_globus.py
+++ b/bdbag/fetch/transports/fetch_globus.py
@@ -64,7 +64,8 @@ def get_file(url, output_path, auth_config, token=None, dest_endpoint=None):
             return False
 
         # initialize transfer client
-        client = globus_sdk.TransferClient(token=token)
+        authorizer = globus_sdk.AccessTokenAuthorizer(token)
+        client = globus_sdk.TransferClient(authorizer=authorizer)
 
         # Activate source endpoint
         logger.debug("Activating source endpoint: %s" % src_endpoint)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
                       'requests',
                       'certifi',
                       'bagit==1.6.2',
-                      'globus-sdk'],
+                      'globus-sdk==1.3.0'],
     license='Apache 2.0',
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
When this part of the client was written a couple years ago, `globus_sdk` supported:

    globus_sdk.TransferClient(token=mytoken)

That changed in future versions, and no version was pinned in the `setup.py`, which eventually caused fetching files on a Globus endpoint to stop working. 

The following changes include the newer version for instantiating a `TransferClient` and pin the current latest version Globus SDK in `setup.py`.